### PR TITLE
Minimize the number of methods that must be implemented.

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -55,7 +55,7 @@ func BenchmarkRP(b *testing.B) { //nostyle:repetition
 		urlstr := testutil.NewUpstreamEchoNGINXServer(b, h) //nostyle:varnames
 		upstreams[h] = urlstr
 	}
-	r := testutil.NewRelayer(upstreams)
+	r := testutil.NewSimpleRelayer(upstreams)
 	proxy := httptest.NewServer(rp.NewRouter(r))
 	b.Cleanup(func() {
 		proxy.Close()

--- a/rp.go
+++ b/rp.go
@@ -12,7 +12,7 @@ import (
 const errorKey = "X-Proxy-Error"
 
 // Relayer is the interface of the implementation that determines the behavior of the reverse proxy
-type Relayer interface {
+type Relayer interface { //nostyle:ifacenames
 	// GetUpstream returns the upstream URL for the given request.
 	// If upstream is not determined, nil may be returned
 	// DO NOT modify the request in this method.
@@ -25,7 +25,7 @@ type Rewriter interface {
 	Rewrite(*httputil.ProxyRequest) error
 }
 
-type CertGetter interface {
+type CertGetter interface { //nostyle:ifacenames
 	// GetCertificate returns the TLS certificate for the given client hello info.
 	GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error)
 }

--- a/rp.go
+++ b/rp.go
@@ -17,21 +17,56 @@ type Relayer interface {
 	// If upstream is not determined, nil may be returned
 	// DO NOT modify the request in this method.
 	GetUpstream(*http.Request) (*url.URL, error)
+}
+
+type Rewriter interface {
 	// Rewrite rewrites the request before sending it to the upstream.
 	// For example, you can set `X-Forwarded-*` header here using [httputil.ProxyRequest.SetXForwarded](https://pkg.go.dev/net/http/httputil#ProxyRequest.SetXForwarded)
 	Rewrite(*httputil.ProxyRequest) error
+}
+
+type CertGetter interface {
 	// GetCertificate returns the TLS certificate for the given client hello info.
 	GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error)
+}
+
+type RoundTripper interface {
 	// RoundTrip performs the round trip of the request.
 	// It is necessary to implement the functions that http.Transport is responsible for (e.g. MaxIdleConnsPerHost).
 	RoundTrip(r *http.Request) (*http.Response, error)
 }
 
+type relayer struct {
+	Relayer
+	Rewrite        func(*httputil.ProxyRequest) error
+	GetCertificate func(*tls.ClientHelloInfo) (*tls.Certificate, error)
+	RoundTrip      func(*http.Request) (*http.Response, error)
+}
+
+func newRelayer(r Relayer) *relayer {
+	rr := &relayer{
+		Relayer: r,
+	}
+	if v, ok := r.(Rewriter); ok {
+		rr.Rewrite = v.Rewrite
+	}
+	if v, ok := r.(CertGetter); ok {
+		rr.GetCertificate = v.GetCertificate
+	}
+	if v, ok := r.(RoundTripper); ok {
+		rr.RoundTrip = v.RoundTrip
+	} else {
+		rr.RoundTrip = http.DefaultTransport.RoundTrip
+	}
+	return rr
+}
+
 // NewRouter returns a new reverse proxy router.
 func NewRouter(r Relayer) http.Handler {
+	rr := newRelayer(r)
 	return &httputil.ReverseProxy{
 		Rewrite: func(pr *httputil.ProxyRequest) {
-			u, err := r.GetUpstream(pr.In)
+			u, err := rr.GetUpstream(pr.In)
 			if err != nil {
 				pr.Out.Header.Set(errorKey, err.Error())
 				return
@@ -40,12 +75,15 @@ func NewRouter(r Relayer) http.Handler {
 				pr.Out.Host = u.Host
 				pr.Out.URL = u
 			}
-			if err := r.Rewrite(pr); err != nil {
+			if rr.Rewrite == nil {
+				return
+			}
+			if err := rr.Rewrite(pr); err != nil {
 				pr.Out.Header.Set(errorKey, err.Error())
 				return
 			}
 		},
-		Transport: newTransport(r),
+		Transport: newTransport(rr),
 	}
 }
 
@@ -61,8 +99,11 @@ func NewServer(addr string, r Relayer) *http.Server {
 // NewTLSServer returns a new reverse proxy TLS server.
 func NewTLSServer(addr string, r Relayer) *http.Server {
 	rp := NewRouter(r)
+	rr := newRelayer(r)
 	tc := new(tls.Config)
-	tc.GetCertificate = r.GetCertificate
+	if rr.GetCertificate != nil {
+		tc.GetCertificate = rr.GetCertificate
+	}
 	return &http.Server{
 		Addr:      addr,
 		Handler:   rp,
@@ -83,7 +124,7 @@ func ListenAndServeTLS(addr string, r Relayer) error {
 }
 
 type transport struct {
-	r Relayer
+	rr *relayer
 }
 
 func (t *transport) RoundTrip(r *http.Request) (*http.Response, error) {
@@ -103,9 +144,9 @@ func (t *transport) RoundTrip(r *http.Request) (*http.Response, error) {
 		}
 		return resp, nil
 	}
-	return t.r.RoundTrip(r)
+	return t.rr.RoundTrip(r)
 }
 
-func newTransport(r Relayer) *transport {
-	return &transport{r: r}
+func newTransport(rr *relayer) *transport {
+	return &transport{rr: rr}
 }

--- a/rp_test.go
+++ b/rp_test.go
@@ -47,7 +47,7 @@ func TestHTTPRouting(t *testing.T) {
 				us := testutil.NewUpstreamServer(t, u.hostname)
 				m[u.hostname] = us.URL + u.rootPath
 			}
-			r := testutil.NewRelayer(m)
+			r := testutil.NewSimpleRelayer(m)
 			port, err := testutil.NewPort()
 			if err != nil {
 				t.Fatal(err)

--- a/testutil/relayer.go
+++ b/testutil/relayer.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"os"
 	"path"
@@ -36,11 +35,6 @@ func (r *Relayer) GetUpstream(req *http.Request) (*url.URL, error) {
 	return nil, fmt.Errorf("not found upstream: %v", host)
 }
 
-func (r *Relayer) Rewrite(pr *httputil.ProxyRequest) error {
-	pr.SetXForwarded()
-	return nil
-}
-
 func (r *Relayer) GetCertificate(i *tls.ClientHelloInfo) (*tls.Certificate, error) {
 	cert := fmt.Sprintf("testdata/%s.cert.pem", i.ServerName)
 	key := fmt.Sprintf("testdata/%s.key.pem", i.ServerName)
@@ -55,8 +49,4 @@ func (r *Relayer) GetCertificate(i *tls.ClientHelloInfo) (*tls.Certificate, erro
 		return nil, err
 	}
 	return &c, nil
-}
-
-func (r *Relayer) RoundTrip(req *http.Request) (*http.Response, error) {
-	return http.DefaultTransport.RoundTrip(req)
 }


### PR DESCRIPTION
With the existing Relayer interface, it is necessary to be aware of httputil.ReverseProxy.

Improve it by minimizing the methods needed to implement a reverse proxy at a minimum.