### PR TITLE
Make it possible to proxy through a Unix domain socket.

### DIFF
--- a/rp.go
+++ b/rp.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 )
 
 const errorKey = "X-Proxy-Error"
@@ -73,7 +74,11 @@ func NewRouter(r Relayer) http.Handler {
 					return
 				}
 				if u != nil {
-					pr.Out.Host = u.Host
+					if strings.HasPrefix(u.Host, "/") {
+						pr.Out.Host = pr.In.Host
+					} else {
+						pr.Out.Host = u.Host
+					}
 					pr.Out.URL = u
 					pr.SetXForwarded()
 				}
@@ -89,9 +94,13 @@ func NewRouter(r Relayer) http.Handler {
 				return
 			}
 			if u != nil {
-				pr.Out.Host = u.Host
-				pr.Out.URL = u
+				if strings.HasPrefix(u.Host, "/") {
+					pr.Out.Host = pr.In.Host
+				} else {
+					pr.Out.Host = u.Host
+				}
 
+				pr.Out.URL = u
 			}
 			if err := rr.Rewrite(pr); err != nil {
 				pr.Out.Header.Set(errorKey, err.Error())


### PR DESCRIPTION
```
   proxyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
        // To masquerade the request as being sent to a Unix domain socket,
        // set the request's URL Host to the Unix socket path.
        r.URL.Host = unixSocketPath
        r.URL.Scheme = "http"

        // Use ReverseProxy to proxy the request
        reverseProxy.ServeHTTP(w, r)
    })
```

When using a Unix domain socket, pass the 'in header host' as is to the subsequent process.